### PR TITLE
elf: Ignore bytes in program before first section

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -8,6 +8,10 @@ use object::{
 
 use crate::Result;
 
+/// This function effectively does an in-memory `objcopy -O binary ${ELF} ${OUTPUT}` (at least for
+/// the working inputs): Given an ELF file, it produces all bytes of the to-be-loaded program from
+/// the first section, from that byte on. The address of that start is dicarded; any gaps between
+/// programs inside the ELF file are populated with zeros.
 pub fn read_elf_image(elf: &[u8]) -> Result<Vec<u8>> {
     struct Chunk<'a> {
         flash_addr: u32,


### PR DESCRIPTION
Some binaries that can be flashed correctly via nrfutil (by objdump'ing the file into ihex and running `nrfutil pkg generate`) can not be flashed with nrfdfu because it copies the whole elf program out, checking for the start but disregarding that the first section may not even be at the start of the program data.

This PR enhances the trace output and refactors to the point where those programs work.

I do have some changes around that'd establish test cases (I ran tests here but it's hard to verify those remotely), but that'd depend on either building 3rd party projects during the tests, or checking in binaries to the source tree, or hand-crafting ELF files (which I wouldn't even know how to do); should I add the checked-in files as a regression test, or do you have different preferences?

[edit:] If this is accepted, RIOT could finally switch over to a free programming tool for nrf52840dongle & similar boards; see https://github.com/RIOT-OS/RIOT/pull/21466.