### PR TITLE
Add `--all` option

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -108,7 +108,6 @@ pub fn read_elf_image(elf: &[u8]) -> Result<Vec<u8>> {
         return Err(
             "no loadable program segments found; ensure that the linker is \
             invoked correctly (passing the linker script)"
-                .to_string()
                 .into(),
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,6 @@ fn run() -> Result<()> {
             return Err(
                 "no matching USB serial device found.\n       Remember to put the \
                                  device in bootloader mode by pressing the reset button!"
-                    .to_string()
                     .into(),
             )
         }
@@ -99,11 +98,7 @@ fn run() -> Result<()> {
                 .timeout(Duration::from_millis(1000))
                 .open()?
         }
-        _ => {
-            return Err("multiple matching USB serial devices found"
-                .to_string()
-                .into())
-        }
+        _ => return Err("multiple matching USB serial devices found".into()),
     };
 
     // On Windows, this is required, otherwise communication fails with timeouts

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn run() -> Result<()> {
         })
         .collect();
 
-    let mut port = match matching_ports.len() {
+    let port = match matching_ports.len() {
         0 => {
             return Err(
                 "no matching USB serial device found.\n       Remember to put the \
@@ -110,6 +110,12 @@ fn run() -> Result<()> {
         _ => return Err("multiple matching USB serial devices found".into()),
     };
 
+    run_on_port(port, &args, image.as_deref())?;
+
+    Ok(())
+}
+
+fn run_on_port(mut port: Box<dyn SerialPort>, args: &Args, image: Option<&[u8]>) -> Result<()> {
     // On Windows, this is required, otherwise communication fails with timeouts
     // (or just hangs forever).
     port.write_data_terminal_ready(true)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,12 @@ struct Args {
     /// Reboots into the application even if no other application was performed.
     #[arg(long)]
     abort: bool,
+
+    /// Runs the command on *all* recognized devices after printing the port's details.
+    ///
+    /// Errors are accumulated and reported after all ports have been tried.
+    #[arg(long)]
+    all: bool,
 }
 
 fn run() -> Result<()> {
@@ -101,11 +107,31 @@ fn run() -> Result<()> {
             )
         }
         1 => (),
-        _ => return Err("multiple matching USB serial devices found".into()),
+        _ => {
+            if !args.all {
+                return Err("multiple matching USB serial devices found".into());
+            }
+        }
     };
 
+    let mut errors_in_all = false;
+
     for port in matching_ports {
-        run_on_port(port, &args, image.as_deref())?;
+        let result = run_on_port(&port, &args, image.as_deref());
+        if let Err(e) = result {
+            if args.all {
+                // The current port is printed in run_on_port anyway, but it doesn't hurt to be
+                // explicit, especially since stdout and stderr might not be sorted properly.
+                eprintln!("error processing {}: {e}", &port.port_name);
+                errors_in_all = true;
+            } else {
+                return Err(e);
+            }
+        }
+    }
+
+    if errors_in_all {
+        return Err("At least one error occurred on a single port.".into());
     }
 
     if image.is_none() && !args.get_images && !args.abort {
@@ -117,8 +143,23 @@ fn run() -> Result<()> {
     Ok(())
 }
 
-fn run_on_port(port: serialport::SerialPortInfo, args: &Args, image: Option<&[u8]>) -> Result<()> {
+fn run_on_port(port: &serialport::SerialPortInfo, args: &Args, image: Option<&[u8]>) -> Result<()> {
     log::debug!("opening {} (type {:?})", port.port_name, port.port_type);
+    if args.all {
+        let serial = match &port.port_type {
+            serialport::SerialPortType::UsbPort(s) => s.serial_number.as_ref(),
+            // Those don't get through filtering anyway
+            _ => None,
+        };
+        println!(
+            "Port {} (serial: {})",
+            port.port_name,
+            serial
+                .map(|s| format!("{:?}", s))
+                .unwrap_or("unknown".into())
+        );
+    }
+
     let mut port = serialport::new(&port.port_name, 115200)
         .timeout(Duration::from_millis(1000))
         .open()?;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -459,9 +459,7 @@ pub fn parse_response<R: Request>(buf: &[u8]) -> crate::Result<R::Response> {
                 .into());
             }
             None => {
-                return Err("malformed response (missing extended error byte)"
-                    .to_string()
-                    .into());
+                return Err("malformed response (missing extended error byte)".into());
             }
         },
         code => {
@@ -477,7 +475,7 @@ pub fn parse_response<R: Request>(buf: &[u8]) -> crate::Result<R::Response> {
     let response = R::Response::read_payload(&mut response_bytes)?;
 
     if !response_bytes.is_empty() {
-        return Err("trailing bytes in response".to_string().into());
+        return Err("trailing bytes in response".into());
     }
 
     Ok(response)


### PR DESCRIPTION
This option applies the requested operation at *all* connected bootloaders.

There's one use case I think for which this is really practical: listing the devices using `--get-image` or `--all`.

When `--all` is given, the device (and serial number) is shown in front of all items, so you might get:

```
$ nrfdfu --all
Port /dev/ttyACM2 (serial: "EB86723B4658")
Port /dev/ttyACM3 (serial: "D2C505A7E0C6")
error: No actions performed; provide an .elf file on the command line to flash, or set querying options.
$ nrfdfu --all --get-images
Port /dev/ttyACM2 (serial: "EB86723B4658")
* image 0: Bootloader, version 0. Starting 0xe0000, length 122880.
* image 1: Application, version 0. Starting 0x1000, length 9412.
Port /dev/ttyACM3 (serial: "D2C505A7E0C6")
* image 0: Bootloader, version 0. Starting 0xe0000, length 122880.
* image 1: Application, version 0. Starting 0x1000, length 19556.
```

I'm not sure there are use cases for all combinations, but they kind of fall out neatly from how things are set up -- so you can also flash a file to all connected chips (convenient device-to-device tests) or reboot them all into the firmware. The most useful application IMO is getting the serial numbers for later use with `--serial` -- that wouldn't need `--all` fundamentally, but it fits nicely. I'm open to other ideas just as well (eg. not making it too `--all`ish and instead having a `--list` option that behaves largely like `--all` now standalone, but only combines with `--get-images`). Or anything else that makes this better user-experience-wise.