### PR TITLE
Add buffering to serial input/output

### DIFF
--- a/src/slip.rs
+++ b/src/slip.rs
@@ -20,7 +20,8 @@ pub fn encode_frame(buf: &[u8], mut writer: impl Write) -> io::Result<()> {
 }
 
 pub fn decode_frame(reader: impl Read, buf: &mut Vec<u8>) -> io::Result<()> {
-    let mut bytes = reader.bytes();
+    let bufreader = std::io::BufReader::new(reader);
+    let mut bytes = bufreader.bytes();
     loop {
         let encoded_byte = match bytes.next() {
             Some(byte) => byte,


### PR DESCRIPTION
clippy points out that iterating over bytes (with `.bytes()`) on a plain `impl io::Read` is expensive because each byte will be a sys call.

It benchmarks it makes basically no difference, because we read so little back from the device, but sure - why not.
