### PR TITLE
serialport: Disable udev dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,26 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,12 +277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +311,6 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "io-kit-sys",
- "libudev",
  "mach2",
  "nix",
  "scopeguard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = { version = "0.9.0", default-features = false, features = ["termcol
 leb128 = "0.2.4"
 log = "0.4.14"
 object = { version = "0.25.3", default-features = false, features = ["elf", "read_core", "std"] }
-serialport = { version = "4.7" }
+serialport = { version = "4.7", default-features = false }
 sha2 = "0.9.3"
 
 [dev-dependencies]


### PR DESCRIPTION
This affects only Linux and "won't expose as much information and may return ports that don't exist physically", but it does expose VID/PID and serial number, and the nonexisting devices should not affect USB either.

---

The reason to do this is to cut build dependencies. (The underlying effort in serialport was [done](https://github.com/serialport/serialport-rs/pull/220) for probe-rs for the benefit of not pulling libudev as a build dependency in there).

In theory this might speed up builds, but my timings vary too much to say whether the speedup is significant.