### PR TITLE
Describe required Rust version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Build
         run: cargo build
+  build-announced:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install MSRV
+        run: rustup toolchain add 1.82
+      - name: Build
+        run: cargo +1.82 build
   format-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,10 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install pkg-config libudev-dev libusb-1.0-0-dev
       - name: Build
         run: cargo build
   format-check:
@@ -36,10 +32,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install pkg-config libudev-dev libusb-1.0-0-dev
       - name: Test
         run: cargo test
   clippy:
@@ -47,9 +39,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install pkg-config libudev-dev libusb-1.0-0-dev
       - name: Clippy
         run: cargo clippy --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = [
     "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>",
 ]
 edition = "2018"
+# Keep in sync with .github/workflows/check.yml
+rust-version = "1.82.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "A flashing tool for the nRF bootloader"


### PR DESCRIPTION
Setting rust-version ensures that users get usable error messages when their setup is wrong rather than "no method named `is_none_or` found for enum `Option`".

Removing dependencies from before #27 is useful by-catch.